### PR TITLE
SRP6 registration

### DIFF
--- a/Trinity Account Creator/php/createAccount.php
+++ b/Trinity Account Creator/php/createAccount.php
@@ -49,7 +49,7 @@
     // Get the SHA1 encrypted password.
     list($salt, $verifier) = $db->getRegistrationData($username, $password);
     
-    $accountCreateQuery = "INSERT INTO account(username, salt, verifier, email) VALUES(?, ?, ?)";
+    $accountCreateQuery = "INSERT INTO account(username, salt, verifier, email) VALUES(?, ?, ?, ?)";
     $accountCreateParams = array($username, $salt, $verifier, $email);
     
     // Execute the query.

--- a/Trinity Account Creator/php/createAccount.php
+++ b/Trinity Account Creator/php/createAccount.php
@@ -47,10 +47,10 @@
     // If no account exists, create a new one.
     
     // Get the SHA1 encrypted password.
-    $shaPassword = $db->getShaPasswordHash($username, $password);
+    list($salt, $verifier) = $db->getRegistrationData($username, $password);
     
-    $accountCreateQuery = "INSERT INTO account(username, sha_pass_hash, email) VALUES(?, ?, ?)";
-    $accountCreateParams = array($username, $shaPassword[0], $email);
+    $accountCreateQuery = "INSERT INTO account(username, salt, verifier, email) VALUES(?, ?, ?)";
+    $accountCreateParams = array($username, $salt, $verifier, $email);
     
     // Execute the query.
     $db->insertQuery($accountCreateQuery, $accountCreateParams);

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -122,7 +122,7 @@
       $salt = random_bytes(32);
       
       // calculate verifier using this salt
-      $verifier = calculateSRP6Verifier($username, $password, $salt);
+      $verifier = $this->calculateSRP6Verifier($username, $password, $salt);
 
       // done - this is what you put in the account table!
       return array($salt, $verifier);

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -87,18 +87,45 @@
       return $this->conn->lastInsertId();
     }
     
-    // Returns a SHA1 encrypted password from the database.
-    // Note that the result is a numbered array, not associative.
-    public function getShaPasswordHash($username, $password) {
+    private function calculateSRP6Verifier($username, $password, $salt)
+    {
+      // algorithm constants
+      $g = gmp_init(7);
+      $N = gmp_init('894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7', 16);
+
+      // calculate first hash
+      $h1 = sha1(strtoupper($username . ':' . $password), TRUE);
+
+      // calculate second hash
+      $h2 = sha1($salt.$h1, TRUE);
+
+      // convert to integer (little-endian)
+      $h2 = gmp_import($h2, 1, GMP_LSW_FIRST);
+
+      // g^h2 mod N
+      $verifier = gmp_powm($g, $h2, $N);
+
+      // convert back to a byte array (little-endian)
+      $verifier = gmp_export($verifier, 1, GMP_LSW_FIRST);
+
+      // pad to 32 bytes, remember that zeros go on the end in little-endian!
+      $verifier = str_pad($verifier, 32, chr(0), STR_PAD_RIGHT);
+
+      // done!
+      return $verifier;
+    }
+    
+    // Returns SRP6 parameters to register this username/password combination with
+    public function getRegistrationData($username, $password)
+    {
+      // generate a random salt
+      $salt = random_bytes(32);
       
-      $query = "SELECT SHA1(CONCAT(UPPER(?), ':', UPPER(?)));";
-      $params = array($username, $password);
-      
-      $stmt = $this->conn->prepare($query);
-      $stmt->execute($params);
-      $row = $stmt->fetch(PDO::FETCH_NUM);
-      
-      return $row;
+      // calculate verifier using this salt
+      $verifier = calculateSRP6Verifier($username, $password, $salt);
+
+      // done - this is what you put in the account table!
+      return array($salt, $verifier);
     }
     
     // Close the database connection.


### PR DESCRIPTION
Create accounts using SRP6 `salt`/`verifier` instead of `sha_pass_hash`, see TrinityCore/TrinityCore#25157.

Requires TrinityCore/TrinityCore#25135.