### PR TITLE
Improvements for account creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Projects created for use with the TrinityCore World of Warcraft emulator: https://www.trinitycore.org/
 
 # Requirements
+
+#### PHP Version >= 5.0.0
+
 [gmp](https://www.php.net/manual/en/book.gmp.php) module is required to be enabled in PHP.  
  * On Linux do `sudo apt install php-gmp`  
  * On Windows you should have `php_gmp.dll` in your extensions folder of your PHP installation  

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 Projects created for use with the TrinityCore World of Warcraft emulator: https://www.trinitycore.org/
 
 # Requirements
- gmp module is required to be enabled in PHP. On linux this means either `sudo apt install php-gmp` or editing the default php.ini and uncomment the `extension=gmp` line  
+[gmp](https://www.php.net/manual/en/book.gmp.php) module is required to be enabled in PHP.  
+ * On Linux do `sudo apt install php-gmp`  
+ * On Windows you should have `php_gmp.dll` in your extensions folder of your PHP installation  
+ * Edit the default php.ini and uncomment the `extension=gmp` line.  
  
- pdo_mysql module is required to be enabled in PHP. On linux this means either `sudo apt install php-mysql` or editing the default php.ini and uncomment the `extension=pdo_mysql` line  
- 
- mbstring module is required to be enabled in PHP. On linux this means either `sudo apt install php-mbstring` or editing the default php.ini and uncomment the `extension=mbstring` line  
+[pdo_mysql](https://www.php.net/manual/en/ref.pdo-mysql.php) module is required to be enabled in PHP.  
+ * On Linux do `sudo apt install php-mysql`  
+ * On Windows you should have `php_pdo_mysql.dll` in your extensions folder of your PHP installation  
+ * Edit the default php.ini and uncomment the `extension=pdo_mysql` line.  

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Projects created for use with the TrinityCore World of Warcraft emulator: https://www.trinitycore.org/
 
 # Requirements
- gmp module is required to be enabled in PHP. On linux this means either `sudo apt install php-gmp` or editing the default php.ini and uncomment the `extension=gmp` line
- pdo_mysql module is required to be enabled in PHP. On linux this means either `sudo apt install php-mysql` or editing the default php.ini and uncomment the `extension=pdo_mysql` line
- mbstring module is required to be enabled in PHP. On linux this means either `sudo apt install php-mbstring` or editing the default php.ini and uncomment the `extension=mbstring` line
+ gmp module is required to be enabled in PHP. On linux this means either `sudo apt install php-gmp` or editing the default php.ini and uncomment the `extension=gmp` line  
+ 
+ pdo_mysql module is required to be enabled in PHP. On linux this means either `sudo apt install php-mysql` or editing the default php.ini and uncomment the `extension=pdo_mysql` line  
+ 
+ mbstring module is required to be enabled in PHP. On linux this means either `sudo apt install php-mbstring` or editing the default php.ini and uncomment the `extension=mbstring` line  

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ Projects created for use with the TrinityCore World of Warcraft emulator: https:
 
 # Requirements
  gmp module is required to be enabled in PHP. On linux this means either `sudo apt install php-gmp` or editing the default php.ini and uncomment the `extension=gmp` line
+ pdo_mysql module is required to be enabled in PHP. On linux this means either `sudo apt install php-mysql` or editing the default php.ini and uncomment the `extension=pdo_mysql` line
+ mbstring module is required to be enabled in PHP. On linux this means either `sudo apt install php-mbstring` or editing the default php.ini and uncomment the `extension=mbstring` line

--- a/Trinity Account Creator/index.html
+++ b/Trinity Account Creator/index.html
@@ -72,6 +72,13 @@
           />
         </form>
       </div>
+      <!--
+	  <div class="container formContainer">
+	    <div>
+	      <p>Realmlist: 127.0.0.1</p>
+	    </div>
+	  </div>
+	  -->
     </main>
 
     <!-- Footer -->

--- a/Trinity Account Creator/js/script.js
+++ b/Trinity Account Creator/js/script.js
@@ -52,7 +52,7 @@ function submitForm() {
           document.getElementById('statusMessage').value = 'Password is empty.';
           document.getElementById('statusMessage').style.color = 'yellow';
         } else if (xhr.responseText == '7') {
-          document.getElementById('statusMessage').value = 'Password is invalid.';
+          document.getElementById('statusMessage').value = 'Password is too long.';
           document.getElementById('statusMessage').style.color = 'yellow';
         } else if (xhr.responseText == '8') {
           document.getElementById('statusMessage').value = 'Email is empty.';

--- a/Trinity Account Creator/js/script.js
+++ b/Trinity Account Creator/js/script.js
@@ -23,26 +23,36 @@ function submitForm() {
 
   // Create a callback function.
   xhr.onreadystatechange = function() {
-    if (xhr.readyState == 4 && xhr.status == 200) {
-      // Transaction was successful.
-      if (xhr.responseText == '0') {
-        // Reset the form first.
-        document.getElementById('accountForm').reset();
+    if (xhr.readyState == 4) {
+      if (xhr.status == 200) {
+        // Transaction was successful.
+        if (xhr.responseText == '0') {
+          // Reset the form first.
+          document.getElementById('accountForm').reset();
 
-        // Update the status message.
+          // Update the status message.
+          document.getElementById('statusMessage').value =
+            'Account created successfully!';
+          document.getElementById('statusMessage').style.color = 'green';
+        } else if (xhr.responseText == '1') {
+          document.getElementById('statusMessage').value = 'Email is invalid.';
+          document.getElementById('statusMessage').style.color = 'yellow';
+        } else if (xhr.responseText == '2') {
+          document.getElementById('statusMessage').value =
+            'Account already exists.';
+          document.getElementById('statusMessage').style.color = 'red';
+        } else if (xhr.responseText == '3') {
+          document.getElementById('statusMessage').value =
+            'Connection failed.';
+          document.getElementById('statusMessage').style.color = 'red';
+        } else {
+          document.getElementById('statusMessage').value =
+            'Unknown error occurred.';
+          document.getElementById('statusMessage').style.color = 'red';
+        }
+      } else {
         document.getElementById('statusMessage').value =
-          'Account created successfully!';
-        document.getElementById('statusMessage').style.color = 'green';
-      } else if (xhr.responseText == '1') {
-        document.getElementById('statusMessage').value = 'Email is invalid.';
-        document.getElementById('statusMessage').style.color = 'yellow';
-      } else if (xhr.responseText == '2') {
-        document.getElementById('statusMessage').value =
-          'Account already exists.';
-        document.getElementById('statusMessage').style.color = 'red';
-      } else if (xhr.responseText == '3') {
-        document.getElementById('statusMessage').value =
-          'Unknown error occurred.<br>Please try again.';
+          'Unknown error occurred.';
         document.getElementById('statusMessage').style.color = 'red';
       }
     }
@@ -59,3 +69,6 @@ $('#accountForm').submit(function(event) {
   // Cancel the form submission, so we can use AJAX instead.
   event.preventDefault();
 });
+
+// Reset status message on page reload
+document.getElementById('statusMessage').value = '';

--- a/Trinity Account Creator/js/script.js
+++ b/Trinity Account Creator/js/script.js
@@ -31,28 +31,41 @@ function submitForm() {
           document.getElementById('accountForm').reset();
 
           // Update the status message.
-          document.getElementById('statusMessage').value =
-            'Account created successfully!';
+          document.getElementById('statusMessage').value = 'Account created successfully!';
           document.getElementById('statusMessage').style.color = 'green';
         } else if (xhr.responseText == '1') {
-          document.getElementById('statusMessage').value = 'Email is invalid.';
-          document.getElementById('statusMessage').style.color = 'yellow';
+          document.getElementById('statusMessage').value = 'Account already exists.';
+          document.getElementById('statusMessage').style.color = 'red';
         } else if (xhr.responseText == '2') {
-          document.getElementById('statusMessage').value =
-            'Account already exists.';
+          document.getElementById('statusMessage').value = 'Connection failed.';
           document.getElementById('statusMessage').style.color = 'red';
         } else if (xhr.responseText == '3') {
-          document.getElementById('statusMessage').value =
-            'Connection failed.';
-          document.getElementById('statusMessage').style.color = 'red';
+          document.getElementById('statusMessage').value = 'Username is empty.';
+          document.getElementById('statusMessage').style.color = 'yellow';
+        } else if (xhr.responseText == '4') {
+          document.getElementById('statusMessage').value = 'Username is invalid.';
+          document.getElementById('statusMessage').style.color = 'yellow';
+        } else if (xhr.responseText == '5') {
+          document.getElementById('statusMessage').value = 'Username is too long.';
+          document.getElementById('statusMessage').style.color = 'yellow';
+        } else if (xhr.responseText == '6') {
+          document.getElementById('statusMessage').value = 'Password is empty.';
+          document.getElementById('statusMessage').style.color = 'yellow';
+        } else if (xhr.responseText == '7') {
+          document.getElementById('statusMessage').value = 'Password is invalid.';
+          document.getElementById('statusMessage').style.color = 'yellow';
+        } else if (xhr.responseText == '8') {
+          document.getElementById('statusMessage').value = 'Email is empty.';
+          document.getElementById('statusMessage').style.color = 'yellow';
+        } else if (xhr.responseText == '9') {
+          document.getElementById('statusMessage').value = 'Email is invalid.';
+          document.getElementById('statusMessage').style.color = 'yellow';
         } else {
-          document.getElementById('statusMessage').value =
-            'Unknown error occurred.';
+          document.getElementById('statusMessage').value = 'Unknown error occurred.';
           document.getElementById('statusMessage').style.color = 'red';
         }
       } else {
-        document.getElementById('statusMessage').value =
-          'Unknown error occurred.';
+        document.getElementById('statusMessage').value = 'Unknown error occurred.';
         document.getElementById('statusMessage').style.color = 'red';
       }
     }

--- a/Trinity Account Creator/php/compat_random.php
+++ b/Trinity Account Creator/php/compat_random.php
@@ -42,15 +42,38 @@ if (!is_callable('random_bytes')) {
         return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
       }
     }
+  } elseif (class_exists('\\COM')) {
+    try {
+      $util = new COM('CAPICOM.Utilities.1');
+      $method = array($util, 'GetRandom');
+      if (is_callable($method)) {
+        function random_bytes($b) {
+          $util = new \COM('CAPICOM.Utilities.1');
+          $rand = base64_decode($util->GetRandom($b,0));
+          $rand = str_pad($rand, $b, chr(0));
+          return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+        }
+      }
+    } catch (Exception $e) { }
   }
 
   if (!is_callable('random_bytes')) {
-    function random_bytes($b) {
-      $rand = '';
-      for ($i = 1; $i <= $b; $i++) {
-        $rand .= chr(rand(0,255));
+    if (is_callable('mt_rand')) {
+      function random_bytes($b) {
+        $rand = '';
+        for ($i = 1; $i <= $b; $i++) {
+          $rand .= chr(mt_rand(0,255));
+        }
+        return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
       }
-      return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+    } else {
+      function random_bytes($b) {
+        $rand = '';
+        for ($i = 1; $i <= $b; $i++) {
+          $rand .= chr(rand(0,255));
+        }
+        return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+      }
     }
   }
 }

--- a/Trinity Account Creator/php/compat_random.php
+++ b/Trinity Account Creator/php/compat_random.php
@@ -9,15 +9,7 @@ function bytelen($str) {
 }
 
 if (!is_callable('random_bytes')) {
-  if (is_callable('gmp_random_bits')) {
-    function random_bytes($b) {
-      $rand = '';
-      for ($i = 1; $i <= $b; $i++) {
-        $rand .= chr(gmp_intval(gmp_random_bits(8)));
-      }
-      return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
-    }
-  } else if (is_callable('openssl_random_pseudo_bytes')) {
+  if (is_callable('openssl_random_pseudo_bytes')) {
     function random_bytes($b) {
       $rand = openssl_random_pseudo_bytes($b);
       return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
@@ -42,7 +34,7 @@ if (!is_callable('random_bytes')) {
         return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
       }
     }
-  } elseif (class_exists('\\COM')) {
+  } else if (class_exists('\\COM')) {
     try {
       $util = new COM('CAPICOM.Utilities.1');
       $method = array($util, 'GetRandom');
@@ -50,7 +42,7 @@ if (!is_callable('random_bytes')) {
         function random_bytes($b) {
           $util = new \COM('CAPICOM.Utilities.1');
           $rand = base64_decode($util->GetRandom($b,0));
-          $rand = str_pad($rand, $b, chr(0));
+          $rand = ($rand !== false) ? str_pad($rand, $b, chr(0)) : false;
           return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
         }
       }
@@ -58,7 +50,15 @@ if (!is_callable('random_bytes')) {
   }
 
   if (!is_callable('random_bytes')) {
-    if (is_callable('mt_rand')) {
+    if (is_callable('gmp_random_bits')) {
+      function random_bytes($b) {
+        $rand = '';
+        for ($i = 1; $i <= $b; $i++) {
+          $rand .= chr(gmp_intval(gmp_random_bits(8)));
+        }
+        return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+      }
+    } else if (is_callable('mt_rand')) {
       function random_bytes($b) {
         $rand = '';
         for ($i = 1; $i <= $b; $i++) {
@@ -75,6 +75,24 @@ if (!is_callable('random_bytes')) {
         return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
       }
     }
+  }
+}
+
+if (!is_callable('random_int')) {
+  if (is_callable('gmp_random_range')) {
+      function random_int($min, $max) {
+        return gmp_intval(gmp_random_range($min, $max));
+      }
+  } elseif (is_callable('mt_rand')) {
+      function random_int($min, $max) {
+        mt_srand(random_bytes(3));
+        return mt_rand($min, $max);
+      }
+  } elseif (is_callable('rand')) {
+      function random_int($min, $max) {
+        srand(random_bytes(3));
+        return rand($min, $max);
+      }
   }
 }
 

--- a/Trinity Account Creator/php/compat_random.php
+++ b/Trinity Account Creator/php/compat_random.php
@@ -1,0 +1,58 @@
+<?php
+
+function bytelen($str) {
+  if (defined('MB_OVERLOAD_STRING') && (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING) && extension_loaded('mbstring')) {
+    return mb_strlen($str, '8bit');
+  } else {
+    return strlen($str);
+  }
+}
+
+if (!is_callable('random_bytes')) {
+  if (is_callable('gmp_random_bits')) {
+    function random_bytes($b) {
+      $rand = '';
+      for ($i = 1; $i <= $b; $i++) {
+        $rand .= chr(gmp_intval(gmp_random_bits(8)));
+      }
+      return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+    }
+  } else if (is_callable('openssl_random_pseudo_bytes')) {
+    function random_bytes($b) {
+      $rand = openssl_random_pseudo_bytes($b);
+      return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+    }
+  } else if (is_callable('mcrypt_create_iv')) {
+    if (DIRECTORY_SEPARATOR === '/') {
+      function random_bytes($b) {
+        $rand = mcrypt_create_iv($b, MCRYPT_DEV_URANDOM);
+        return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+      }
+    } else {
+      function random_bytes($b) {
+        $rand = mcrypt_create_iv($b);
+        return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+      }
+    }
+  } else if (DIRECTORY_SEPARATOR === '/') {
+    $stat = @stat('/dev/urandom');
+    if ($stat !== false && ($stat['mode'] & 0170000) === 020000) {
+      function random_bytes($b) {
+        $rand = @file_get_contents('/dev/urandom', false, null, 0, $b);
+        return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+      }
+    }
+  }
+
+  if (!is_callable('random_bytes')) {
+    function random_bytes($b) {
+      $rand = '';
+      for ($i = 1; $i <= $b; $i++) {
+        $rand .= chr(rand(0,255));
+      }
+      return ($rand !== false && bytelen($rand) == $b) ? $rand : null;
+    }
+  }
+}
+
+?>

--- a/Trinity Account Creator/php/createAccount.php
+++ b/Trinity Account Creator/php/createAccount.php
@@ -2,7 +2,11 @@
 
   // explicitly set charset to utf-8
   ini_set('default_charset', 'utf-8');
-
+  if(ini_get('mbstring.func_overload')) {
+    ini_set('mbstring.func_overload', 0);
+  }
+  mb_internal_encoding("UTF-8");
+  
   require_once(dirname(__FILE__) . '/db.php');
 
   $db = new db();
@@ -28,7 +32,7 @@
     echo "4"; // Username is invalid.
     return;
   }
-  if (strlen($username) > 32) {
+  if (mb_strlen($username, '8bit') > 16) {
     echo "5"; // Username is too long.
     return;
   }
@@ -37,8 +41,9 @@
     echo "6"; // Password is empty.
     return;
   }
-  if (strlen($password) > 255) {
-    echo "7"; // Password is invalid.
+  // password has a 16 character limit on 3.3.5.12340 client even when SRP6 does not have such limitation
+  if (mb_strlen($password, 'UTF-8') > 16) {
+    echo "7"; // Password is too long.
     return;
   }
   
@@ -46,7 +51,7 @@
     echo "8"; // Email is empty.
     return;
   }
-  if (strlen($email) > 255) {
+  if (mb_strlen($email, '8bit') > 255) {
     echo "9"; // Email is invalid.
     return;
   }

--- a/Trinity Account Creator/php/createAccount.php
+++ b/Trinity Account Creator/php/createAccount.php
@@ -1,5 +1,8 @@
 <?php
 
+  // explicitly set charset to utf-8
+  ini_set('default_charset', 'utf-8');
+
   require_once(dirname(__FILE__) . '/db.php');
 
   $db = new db();
@@ -15,7 +18,7 @@
     $email = trim($_POST['email']);
     $password = $_POST['password'];
   }
-  
+
   if (!isset($username) || !is_string($username) || empty($username)) {
     echo "3"; // Username is empty.
     return;
@@ -52,6 +55,9 @@
     return;
   }
 
+  $username = strtoupper($username);
+  $email = strtoupper($email);
+
   try {
     
     // First, we need to check if the account name already exists.
@@ -76,8 +82,8 @@
     // Get the SRP6 salt and verifier tokens
     list($salt, $verifier) = $db->getRegistrationData($username, $password);
     
-    $accountCreateQuery = "INSERT INTO account(username, salt, verifier, email) VALUES(?, ?, ?, ?)";
-    $accountCreateParams = array($username, $salt, $verifier, $email);
+    $accountCreateQuery = "INSERT INTO account(username, salt, verifier, reg_mail, email) VALUES(?, ?, ?, ?, ?)";
+    $accountCreateParams = array($username, $salt, $verifier, $email, $email);
     
     // Execute the query.
     $db->insertQuery($accountCreateQuery, $accountCreateParams);

--- a/Trinity Account Creator/php/createAccount.php
+++ b/Trinity Account Creator/php/createAccount.php
@@ -4,6 +4,11 @@
 
   $db = new db();
   
+  if (!$db->isOpen()) {
+    echo "3"; // Connection failed
+    return;
+  }
+  
   // Get POST data and validate.
   if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $username = validateInput($_POST['username']);
@@ -63,11 +68,11 @@
     
   }
   catch(PDOException $e) {
-    echo "3"; // Update status message with unknown error occurred.
+    echo "4"; // Update status message with unknown error occurred.
     error_log("PDO Database error occurred: " . $e->getMessage());
   }
   catch (Exception $e) {
-    echo "3"; // Update status message with unknown error occurred.
+    echo "4"; // Update status message with unknown error occurred.
     error_log("Unknown error occurred: " . $e->getMessage());
   }
   

--- a/Trinity Account Creator/php/createAccount.php
+++ b/Trinity Account Creator/php/createAccount.php
@@ -91,7 +91,7 @@
     // Close connection to the database.
     $db->close();
 
-    error_log("Account created: '" . $username . "' '". $email . "'");
+    //error_log("Account created: '" . $username . "' '". $email . "'");
 
     // Return successful to AJAX call.
     echo "0"; // Account created successfully!

--- a/Trinity Account Creator/php/createAccount.php
+++ b/Trinity Account Creator/php/createAccount.php
@@ -3,7 +3,14 @@
   require_once(dirname(__FILE__) . '/vars.php');
   require_once(dirname(__FILE__) . '/db.php');
 
-  $db = new db();
+  if (class_exists('db')) {
+    $db = new db();
+  }
+  else {
+    echo "-1"; // Unknown error occured.
+    error_log("Error: Class db() could not be initialized.");
+    return;
+  }
 
   if (!$db->isOpen()) {
     echo "2"; // Connection failed

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -6,9 +6,10 @@
     
     /* --------------------- ONLY EDIT THE VALUES BELOW THIS LINE --------------------- */
     
-    private $host = "localhost";      // IP or hostname of your server.
-    private $username = "username";   // Database username.
-    private $password = "password";   // Database password.
+    private $host = "localhost";      // IP or hostname of your database server.
+    private $port = "3306";           // Port of your database server.
+    private $username = "trinity";    // Database username.
+    private $password = "trinity";    // Database password.
     private $dbname = "auth";         // Database name (i.e. "auth").
     
     /* --------------------- DO NOT EDIT ANYTHING BELOW THIS LINE --------------------- */
@@ -19,15 +20,16 @@
       try {
         
         // Establish a new connection to the database.
-        $connection = new PDO("mysql:host=$this->host;dbname=$this->dbname", $this->username, $this->password);
-        
-        // Set the PDO error mode to Exception.
-        $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $connection = new PDO("mysql:host=$this->host;port=$this->port;dbname=$this->dbname", $this->username, $this->password,
+        array(
+          PDO::ATTR_TIMEOUT => 5, // Timeout is 5 seconds
+          PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION // Set PDO error mode to Exception.
+        ));
         
         $this->conn = $connection;
       }
       catch (PDOException $e) {
-        echo "Connection failed: " . $e->getMessage();
+        error_log("Connection failed: " . $e->getMessage());
       }
     }
     
@@ -126,6 +128,10 @@
 
       // done - this is what you put in the account table!
       return array($salt, $verifier);
+    }
+    
+    public function isOpen() {
+    	return ($this->conn != null);
     }
     
     // Close the database connection.

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -2,7 +2,7 @@
 
   // explicitly set charset to utf-8
   ini_set('default_charset', 'utf-8');
-  if(ini_get('mbstring.func_overload') {
+  if(ini_get('mbstring.func_overload')) {
     ini_set('mbstring.func_overload', 0);
   }
   mb_internal_encoding("UTF-8");

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -8,7 +8,7 @@
     
     private $host = "localhost";      // IP or hostname of your database server.
     private $port = "3306";           // Port of your database server.
-    private $username = "trinity";    // Database username.
+    private $username = "root";    // Database username.
     private $password = "trinity";    // Database password.
     private $dbname = "auth";         // Database name (i.e. "auth").
     
@@ -140,12 +140,12 @@
     }
 
     public function strtoupper_az($str) {
-    	//return preg_replace_callback('/[a-z]/',function($matches){return strtoupper($matches[0]);},$str);
-    	return preg_replace_callback('/[a-z]/',function($matches){return chr(ord($matches[0])-32);},$str);
+      //return preg_replace_callback('/[a-z]/',function($matches){return strtoupper($matches[0]);},$str);
+      return preg_replace_callback('/[a-z]/',function($matches){return chr(ord($matches[0])-32);},$str);
     }
 
     public function isOpen() {
-    	return ($this->conn != null);
+      return ($this->conn != null);
     }
 
     // Close the database connection.

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -8,7 +8,7 @@
     
     private $host = "localhost";      // IP or hostname of your database server.
     private $port = "3306";           // Port of your database server.
-    private $username = "root";    // Database username.
+    private $username = "trinity";    // Database username.
     private $password = "trinity";    // Database password.
     private $dbname = "auth";         // Database name (i.e. "auth").
     

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -41,7 +41,7 @@
           $stmt->execute($params);
         }
         catch (PDOException $e) {
-          error_log("Error when inserting a new account: " . $e->getMessage());
+          throw $e;
         }
       }
     }
@@ -49,12 +49,17 @@
     // Fetches and returns the next row from the result set.
     public function querySingleRow($query, $params) {
       if ($query) {
-        $stmt = $this->conn->prepare($query);
-        $stmt->execute($params);
+        try {
+          $stmt = $this->conn->prepare($query);
+          $stmt->execute($params);
         
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+          $row = $stmt->fetch(PDO::FETCH_ASSOC);
         
-        return $row;
+          return $row;
+        }
+        catch (PDOException $e) {
+          throw $e;
+        }
       }
       else
         return null;
@@ -63,12 +68,17 @@
     // Returns an array containing all of the result set rows.
     public function queryMultiRow($query, $params) {
       if ($query) {
-        $stmt = $this->conn->prepare($query);
-        $stmt->execute($params);
+        try {
+          $stmt = $this->conn->prepare($query);
+          $stmt->execute($params);
         
-        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+          $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
         
-        return $results;
+          return $results;
+        }
+        catch (PDOException $e) {
+          throw $e;
+        }
       }
       else
         return null;

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -11,7 +11,7 @@
     
     private $host = "localhost";      // IP or hostname of your database server.
     private $port = "3306";           // Port of your database server.
-    private $username = "root";    // Database username.
+    private $username = "trinity";    // Database username.
     private $password = "trinity";    // Database password.
     private $dbname = "auth";         // Database name (i.e. "auth").
     

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -1,6 +1,7 @@
 <?php
 
   require_once(dirname(__FILE__) . '/vars.php');
+  require_once(dirname(__FILE__) . '/compat_random.php');
 
   class db {
 
@@ -20,11 +21,17 @@
     function __construct() {
       try {
         // Establish a new connection to the database.
-        $connection = new PDO("mysql:host=$this->host;port=$this->port;dbname=$this->dbname;charset=utf8", $this->username, $this->password,
-        array(
+        $options = array(
           PDO::ATTR_TIMEOUT => 5, // Timeout is 5 seconds
           PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION // Set PDO error mode to Exception.
-        ));
+        );
+        if (version_compare(PHP_VERSION, "5.3.6", "<")) {
+          $connection = new PDO("mysql:host=$this->host;port=$this->port;dbname=$this->dbname", $this->username, $this->password, $options);
+          $connection->exec('SET NAMES utf8');
+        }
+        else {
+          $connection = new PDO("mysql:host=$this->host;port=$this->port;dbname=$this->dbname;charset=utf8", $this->username, $this->password, $options);
+        }
 
         $this->conn = $connection;
       }

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -1,4 +1,7 @@
 <?php
+
+  // explicitly set charset to utf-8
+  ini_set('default_charset', 'utf-8');
   
   class db {
     
@@ -8,7 +11,7 @@
     
     private $host = "localhost";      // IP or hostname of your database server.
     private $port = "3306";           // Port of your database server.
-    private $username = "trinity";    // Database username.
+    private $username = "root";    // Database username.
     private $password = "trinity";    // Database password.
     private $dbname = "auth";         // Database name (i.e. "auth").
     
@@ -20,7 +23,7 @@
       try {
         
         // Establish a new connection to the database.
-        $connection = new PDO("mysql:host=$this->host;port=$this->port;dbname=$this->dbname", $this->username, $this->password,
+        $connection = new PDO("mysql:host=$this->host;port=$this->port;dbname=$this->dbname;charset=utf8", $this->username, $this->password,
         array(
           PDO::ATTR_TIMEOUT => 5, // Timeout is 5 seconds
           PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION // Set PDO error mode to Exception.

--- a/Trinity Account Creator/php/db.php
+++ b/Trinity Account Creator/php/db.php
@@ -2,6 +2,10 @@
 
   // explicitly set charset to utf-8
   ini_set('default_charset', 'utf-8');
+  if(ini_get('mbstring.func_overload') {
+    ini_set('mbstring.func_overload', 0);
+  }
+  mb_internal_encoding("UTF-8");
   
   class db {
     

--- a/Trinity Account Creator/php/vars.php
+++ b/Trinity Account Creator/php/vars.php
@@ -1,0 +1,36 @@
+<?php
+
+  // explicitly set charset to utf-8
+  ini_set('default_charset', 'utf-8');
+  ini_set('input_encoding', 'utf-8');
+  ini_set('output_encoding', 'utf-8');
+  ini_set('internal_encoding', 'utf-8');
+  if(ini_get('mbstring.func_overload')) {
+    ini_set('mbstring.func_overload', 0);
+  }
+  if(ini_get('mbstring.detect_order')) {
+    ini_set('mbstring.detect_order', 'pass');
+  }
+  if(ini_get('mbstring.http_input')) {
+    ini_set('mbstring.http_input', 'pass');
+  }
+  if(ini_get('mbstring.http_output')) {
+    ini_set('mbstring.http_output', 'pass');
+  }
+  if(ini_get('mbstring.internal_encoding')) {
+    ini_set('mbstring.internal_encoding', '');
+  }
+  if(ini_get('mbstring.encoding_translation')) {
+    ini_set('mbstring.encoding_translation', 0);
+  }
+  if(ini_get('iconv.input_encoding')) {
+    ini_set('iconv.input_encoding', '');
+  }
+  if(ini_get('iconv.output_encoding')) {
+    ini_set('iconv.input_encoding', '');
+  }
+  if(ini_get('iconv.internal_encoding')) {
+    ini_set('iconv.internal_encoding', '');
+  }
+
+?>

--- a/Trinity Account Creator/php/vars.php
+++ b/Trinity Account Creator/php/vars.php
@@ -1,5 +1,24 @@
 <?php
 
+  function load_lib($n) {
+    return extension_loaded($n) or (function_exists('dl') and dl(((PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '').$n.'.'.PHP_SHLIB_SUFFIX) or false);
+  }
+
+  if (version_compare(PHP_VERSION, "5", "<")) {
+    error_log("Your PHP version is too old, at least version 5.0.0 is required.");
+    die("Error.");
+  }
+
+  if (!load_lib('gmp')) {
+    error_log("Error: Missing PHP module 'gmp'");
+    die("Error.");
+  }
+
+  if (!load_lib('pdo_mysql')) {
+    error_log("Error: Missing PHP module 'pdo_mysql'");
+    die("Error.");
+  }
+
   // explicitly set charset to utf-8
   ini_set('default_charset', 'utf-8');
   ini_set('input_encoding', 'utf-8');

--- a/Trinity Account Creator/php/vars.php
+++ b/Trinity Account Creator/php/vars.php
@@ -46,7 +46,7 @@
     ini_set('iconv.input_encoding', '');
   }
   if(ini_get('iconv.output_encoding')) {
-    ini_set('iconv.input_encoding', '');
+    ini_set('iconv.output_encoding', '');
   }
   if(ini_get('iconv.internal_encoding')) {
     ini_set('iconv.internal_encoding', '');


### PR DESCRIPTION
* Properly return error messages instead of hanging in "Please wait ..." indefinitely
* Add check if database connection succeeded before advancing, return error if not
* Add timeout for database connection, 5 seconds (configurable)
* Add database port option  
* Fix a lot of the implementation
* Throw errors properly (they were all-over-the-place and mishandled before)
* Show the errors to users properly when it's their fault (invalid input) and show "unknown error" to the user on a database/whatever else error and error_log the detailed errors for the administrator
* Fix validation of inputs, throw error on invalid instead, old implementation is all wrong
  - It uses the default value for htmlspecialchars which has ENT_SUBSTITUTE, meaning that inserting invalid characters will pass but get inserted like this " -> &amp;quot; to the database without the user ever knowing
  - stripslashes will do the same, if user enters a username or password with a slash in it, it will pass but with slashes removed without the user knowing
  - It allows inserting whitespace in middle of the username
  - Password shouldn't be validated at all except for the 16-char max req and making (only) latin a-z uppercase, since it's only used to calculate a hash. Any valid UTF-8 characters which are supported by the client can be used as a password. Enter spaces and slashes all you want.

* Check length of inputs (wasn't checked at all)
  - Password can be maximum of 16 UTF-8 characters (which means a maximum of 64 bytes but in real-life scenarios basically max 48 bytes since all the world's languages which are used are in the max 3-bytes codepage). Not that the length would matter at all since it's only used to create the SRP6 32-byte salt & verifier tokens which it's checked against, the password itself is never used. This length limitation is clientside on the 3.3.5.12340 client and an oversight on blizz's part, as there is absolutely no need for such limit
  - Username can be max 16 bytes (which could mean only 3 chinese characters, for example), this is a current TC limitation, need to adhere to it (though it should be checked whether that is indeed correct, since database is set for 32 bytes and I wholly don't believe the clientside limitation for the auth packet size is only 16 bytes, but this would have to be investigated)
  - Email must be < 256 bytes

* Also use the proper implementation of utf-8 character sets for pdo and php both. Make sure that php uses utf-8 for its' functions for this script and also make sure that mbstrinc_func_overload is not used (which could happen if this was dropped in some Drupal/whatever CMS server. All languages which are supported by the client and the server should be now supported by this script too.

* That being said, I'm still not 100% positive it covers all problems which arise with multilingual usernames and their encoding. In any case it's a massive improvement over the original.